### PR TITLE
Fix "Fix renaming bug"

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -373,7 +373,7 @@
       return exec("git diff --name-status " + old_rev + " " + new_rev, {
         maxBuffer: 5000 * 1024
       }, function(error, stdout, stderr) {
-        var data, detail, files, remoteName, _i, _len;
+        var data, detail, files, remoteName, remoteRename, _i, _len;
         if (error) {
           return console.log(("An error occurred when retrieving the 'git diff --name-status " + old_rev + " " + new_rev + "'").bold.red, error);
         }
@@ -384,7 +384,23 @@
             data = detail.split("\t");
             if (data.length > 1) {
               remoteName = _this.config.path.local ? data[1].split(_this.config.path.local).join("") : data[1];
-              if (data[0] === "D") {
+              if (typeof data[2] !== "undefined") {
+                remoteRename = _this.config.path.local ? data[2].split(_this.config.path.local).join("") : data[2];
+              }
+              if (data[0] === "R100") {
+                if (_this.canDelete(data[1])) {
+                  _this.toDelete.push({
+                    name: data[1],
+                    remote: remoteName
+                  });
+                }
+                if (_this.canUpload(data[2])) {
+                  _this.toUpload.push({
+                    name: data[2],
+                    remote: remoteRename
+                  });
+                }
+              } else if (data[0] === "D") {
                 if (_this.canDelete(data[1])) {
                   _this.toDelete.push({
                     name: data[1],

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -279,9 +279,15 @@ module.exports = class Deploy
 					if data.length > 1
 						# If you set a local path, we need to replace the remote name to match the remote path
 						remoteName = if @config.path.local then data[1].split(@config.path.local).join("") else data[1]
+						if typeof data[2] != "undefined"
+							remoteRename = if @config.path.local then data[2].split(@config.path.local).join("") else data[2]
 
+						# The file was renamed
+						if data[0] == "R100"
+							@toDelete.push name:data[1], remote:remoteName if @canDelete data[1]
+							@toUpload.push name:data[2], remote:remoteRename if @canUpload data[2]
 						# The file was deleted
-						if data[0] == "D"
+						else if data[0] == "D"
 							@toDelete.push name:data[1], remote:remoteName if @canDelete data[1]
 						# Everything else
 						else


### PR DESCRIPTION
Hi !

I had this file moving/renaming bug where dploy doesn't seem to handle files move/rename ("R100" in git diff). I saw your fork and your attempt to fix this bug (commit ea476c1) but it didn't work because if there's no rename, data[2] is undefined so it can't split this var, so it crashes. I think that's why you reverted this commit, isn't it?
So I fixed this issue by checking if data[2] is defined. Now it works like a charm: I was able to deploy my changes on my server without any problem. :)